### PR TITLE
Clay/3.3.4 updates

### DIFF
--- a/flow/layers/offscreen_surface.cc
+++ b/flow/layers/offscreen_surface.cc
@@ -10,6 +10,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkSurfaceCharacterization.h"
 #include "third_party/skia/include/utils/SkBase64.h"
+#include "flutter/fml/build_config.h"
 
 namespace flutter {
 
@@ -85,7 +86,7 @@ OffscreenSurface::OffscreenSurface(int64_t texture_id,
       reinterpret_cast<GrRecordingContext*>(surface_context), tex,
       kBottomLeft_GrSurfaceOrigin, 1, kRGBA_8888_SkColorType, colorSpace,
       nullptr, nullptr, nullptr);
-#elif defined(__APPLE__)
+#elif defined(FML_OS_IOS) || defined(FML_OS_MACOSX)
   GrMtlTextureInfo tInfo;
   tInfo.fTexture =
       sk_cfp<const void*>(reinterpret_cast<const void*>(texture_id));

--- a/flow/layers/offscreen_surface.cc
+++ b/flow/layers/offscreen_surface.cc
@@ -4,13 +4,13 @@
 
 #include "flutter/flow/layers/offscreen_surface.h"
 
+#include "flutter/fml/build_config.h"
 #include "third_party/skia/include/core/SkImageEncoder.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/skia/include/core/SkSerialProcs.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkSurfaceCharacterization.h"
 #include "third_party/skia/include/utils/SkBase64.h"
-#include "flutter/fml/build_config.h"
 
 namespace flutter {
 

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -479,7 +479,6 @@ class SceneBuilder extends NativeFieldWrapperClass1 {
       native 'SceneBuilder_pushOpacity';
 
   /// Pushes a color filter operation onto the operation stack.
-  /// TODO: rest of documentation
   BlendEngineLayer pushBlend(
     int alpha,
     BlendMode blendMode, {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -5893,7 +5893,7 @@ class RenderSurface extends NativeFieldWrapperClass1 {
 
   void constructor(int texture) native 'RenderSurface_constructor';
   void setup(int width, int height, void Function() callback) native 'RenderSurface_setup';
-  
+
   void toBytes(ByteBuffer buffer) {
     throw UnimplementedError('toBytes is not implemented for native');
   }

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -5893,6 +5893,14 @@ class RenderSurface extends NativeFieldWrapperClass1 {
 
   void constructor(int texture) native 'RenderSurface_constructor';
   void setup(int width, int height, void Function() callback) native 'RenderSurface_setup';
+  
+  void toBytes(ByteBuffer buffer) {
+    throw UnimplementedError('toBytes is not implemented for native');
+  }
+
+  Image? makeImageSnapshotFromSource(Object src) {
+     throw UnimplementedError('makeImageSnapshotFromSource is not implemented for native');
+  }
 
   Future<void> dispose() async {
     final Completer<void> completer = Completer<void>.sync();

--- a/lib/web_ui/lib/compositing.dart
+++ b/lib/web_ui/lib/compositing.dart
@@ -22,6 +22,8 @@ abstract class ClipPathEngineLayer implements EngineLayer {}
 
 abstract class OpacityEngineLayer implements EngineLayer {}
 
+abstract class BlendEngineLayer implements EngineLayer {}
+
 abstract class ColorFilterEngineLayer implements EngineLayer {}
 
 abstract class ImageFilterEngineLayer implements EngineLayer {}
@@ -68,6 +70,12 @@ abstract class SceneBuilder {
     int alpha, {
     Offset offset = Offset.zero,
     OpacityEngineLayer? oldLayer,
+  });
+  BlendEngineLayer pushBlend(
+    int alpha,
+    BlendMode blendMode, {
+    Offset offset = Offset.zero,
+    BlendEngineLayer? oldLayer,
   });
   ColorFilterEngineLayer pushColorFilter(
     ColorFilter filter, {

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -393,7 +393,7 @@ class RenderSurface extends engine.ManagedSkiaObject<engine.SkSurface> {
     if (surface == null) {
       throw Exception('Failed to create GPU-backed SkSurface for RenderSurface');
     }
-    
+
     return surface;
   }
 

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -32,6 +32,7 @@ export 'engine/canvaskit/image.dart';
 export 'engine/canvaskit/image_filter.dart';
 export 'engine/canvaskit/image_wasm_codecs.dart';
 export 'engine/canvaskit/image_web_codecs.dart';
+export 'engine/canvaskit/image_webhtml_codecs.dart';
 export 'engine/canvaskit/initialization.dart';
 export 'engine/canvaskit/interval_tree.dart';
 export 'engine/canvaskit/layer.dart';

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -14,6 +14,7 @@ import '../util.dart';
 import 'canvaskit_api.dart';
 import 'image_wasm_codecs.dart';
 import 'image_web_codecs.dart';
+import 'image_webhtml_codecs.dart';
 import 'skia_object_cache.dart';
 
 /// Instantiates a [ui.Codec] backed by an `SkAnimatedImage` from Skia.
@@ -29,7 +30,7 @@ FutureOr<ui.Codec> skiaInstantiateImageCodec(Uint8List list,
       targetHeight: targetHeight,
     );
   } else {
-    return CkAnimatedImage.decodeFromBytes(list, 'encoded image bytes');
+    return CkHtmlImage.decodeFromBytes(list, 'encoded image bytes');
   }
 }
 
@@ -93,11 +94,11 @@ void debugRestoreHttpRequestFactory() {
 /// requesting from URI.
 Future<ui.Codec> skiaInstantiateWebImageCodec(
     String url, WebOnlyImageCodecChunkCallback? chunkCallback) async {
-  final Uint8List list = await fetchImage(url, chunkCallback);
   if (browserSupportsImageDecoder) {
+    final Uint8List list = await fetchImage(url, chunkCallback);
     return CkBrowserImageDecoder.create(data: list, debugSource: url.toString());
   } else {
-    return CkAnimatedImage.decodeFromBytes(list, url);
+    return CkHtmlImage.decodeFromUrl(url);
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/image_webhtml_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_webhtml_codecs.dart
@@ -67,7 +67,7 @@ class CkHtmlImage implements ui.Codec {
     assert(_debugCheckIsNotDisposed());
 
     final DomHTMLImageElement img = _imageElement!;
-    
+
     await img.decode();
 
     final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSource(

--- a/lib/web_ui/lib/src/engine/canvaskit/image_webhtml_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_webhtml_codecs.dart
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+library image_webhtml_codecs;
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:ui/ui.dart' as ui;
+import '../dom.dart';
+
+import 'canvaskit_api.dart';
+import 'image.dart';
+
+class CkHtmlImage implements ui.Codec {
+  /// Decodes an image from a list of encoded bytes.
+  CkHtmlImage.decodeFromBytes(this._bytes, this.src) {
+    _imageElement = createDomHTMLImageElement();
+    final DomBlob blob = createDomBlob([this._bytes]);
+    final String url = domWindow.URL.createObjectURL(blob);
+    _imageElement!.src = url;
+  }
+
+  CkHtmlImage.decodeFromUrl(this.src) {
+    _imageElement = createDomHTMLImageElement();
+    _imageElement!.src = src;
+    _imageElement!.crossOrigin = 'anonymous';
+  }
+
+  DomHTMLImageElement? _imageElement;
+
+  final String src;
+  Uint8List? _bytes;
+
+  bool _disposed = false;
+  bool get debugDisposed => _disposed;
+
+  bool _debugCheckIsNotDisposed() {
+    assert(!_disposed, 'This image has been disposed.');
+    return true;
+  }
+
+  @override
+  void dispose() {
+    assert(
+      !_disposed,
+      'Cannot dispose a codec that has already been disposed.',
+    );
+    _disposed = true;
+  }
+
+  @override
+  int get frameCount {
+    assert(_debugCheckIsNotDisposed());
+    return 1;
+  }
+
+  @override
+  int get repetitionCount {
+    assert(_debugCheckIsNotDisposed());
+    return 1;
+  }
+
+  @override
+  Future<ui.FrameInfo> getNextFrame() async {
+    assert(_debugCheckIsNotDisposed());
+
+    final DomHTMLImageElement img = _imageElement!;
+    
+    await img.decode();
+
+    final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSource(
+      _imageElement!,
+      SkPartialImageInfo(
+        alphaType: canvasKit.AlphaType.Premul,
+        colorType: canvasKit.ColorType.RGBA_8888,
+        colorSpace: SkColorSpaceSRGB,
+        width: img.naturalWidth,
+        height: img.naturalHeight,
+      ),
+    );
+
+    final ui.FrameInfo currentFrame = AnimatedImageFrameInfo(
+      const Duration(milliseconds: 10000000),
+      CkImage(skImage!),
+    );
+
+    return Future<ui.FrameInfo>.value(currentFrame);
+  }
+}

--- a/lib/web_ui/lib/src/engine/canvaskit/image_webhtml_codecs.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_webhtml_codecs.dart
@@ -82,7 +82,7 @@ class CkHtmlImage implements ui.Codec {
     );
 
     final ui.FrameInfo currentFrame = AnimatedImageFrameInfo(
-      const Duration(milliseconds: 10000000),
+      const Duration(microseconds: 0),
       CkImage(skImage!),
     );
 

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -351,6 +351,49 @@ class OpacityEngineLayer extends ContainerLayer
   }
 }
 
+/// A layer that paints its children with the given opacity and blend.
+class BlendEngineLayer extends ContainerLayer
+    implements ui.BlendEngineLayer {
+  final int _alpha;
+  final ui.BlendMode _blendMode;
+  final ui.Offset _offset;
+
+  BlendEngineLayer(this._alpha, this._blendMode, this._offset);
+
+  @override
+  void preroll(PrerollContext prerollContext, Matrix4 matrix) {
+    final Matrix4 childMatrix = Matrix4.copy(matrix);
+    childMatrix.translate(_offset.dx, _offset.dy);
+    prerollContext.mutatorsStack
+        .pushTransform(Matrix4.translationValues(_offset.dx, _offset.dy, 0.0));
+    prerollContext.mutatorsStack.pushOpacity(_alpha);
+    super.preroll(prerollContext, childMatrix);
+    prerollContext.mutatorsStack.pop();
+    prerollContext.mutatorsStack.pop();
+    paintBounds = paintBounds.translate(_offset.dx, _offset.dy);
+  }
+
+  @override
+  void paint(PaintContext paintContext) {
+    assert(needsPainting);
+
+    final CkPaint paint = CkPaint();
+    paint.color = ui.Color.fromARGB(_alpha, 0, 0, 0);
+    paint.blendMode = _blendMode;
+
+    paintContext.internalNodesCanvas.save();
+    paintContext.internalNodesCanvas.translate(_offset.dx, _offset.dy);
+    
+    final ui.Rect saveLayerBounds = paintBounds.shift(-_offset);
+
+    paintContext.internalNodesCanvas.saveLayer(saveLayerBounds, paint);
+    paintChildren(paintContext);
+    // Restore twice: once for the translate and once for the saveLayer.
+    paintContext.internalNodesCanvas.restore();
+    paintContext.internalNodesCanvas.restore();
+  }
+}
+
 /// A layer that transforms its child layers by the given transform matrix.
 class TransformEngineLayer extends ContainerLayer
     implements ui.TransformEngineLayer {

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -383,7 +383,7 @@ class BlendEngineLayer extends ContainerLayer
 
     paintContext.internalNodesCanvas.save();
     paintContext.internalNodesCanvas.translate(_offset.dx, _offset.dy);
-    
+
     final ui.Rect saveLayerBounds = paintBounds.shift(-_offset);
 
     paintContext.internalNodesCanvas.saveLayer(saveLayerBounds, paint);

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -179,6 +179,17 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
+  BlendEngineLayer pushBlend(
+    int alpha,
+    ui.BlendMode blendMode, {
+    ui.Offset offset = ui.Offset.zero,
+    ui.EngineLayer? oldLayer,
+  }) {
+    // throw UnimplementedError('not implemented');
+    return pushLayer<BlendEngineLayer>(BlendEngineLayer(alpha, blendMode, offset));
+  }
+
+  @override
   PhysicalShapeEngineLayer pushPhysicalShape({
     required ui.Path path,
     required double elevation,

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -493,6 +493,7 @@ extension DomHTMLImageElementExtension on DomHTMLImageElement {
   external int get naturalHeight;
   external set width(int? value);
   external set height(int? value);
+  external set crossOrigin(String? value);
   Future<dynamic> decode() =>
       js_util.promiseToFuture(js_util.callMethod(this, 'decode', <Object>[]));
 }

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -582,4 +582,9 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ) {
     throw UnimplementedError();
   }
+  
+  @override
+  ui.BlendEngineLayer pushBlend(int alpha, ui.BlendMode blendMode, {ui.Offset offset = ui.Offset.zero, ui.EngineLayer? oldLayer,}) {
+    throw UnimplementedError('Blend is not implemented for the html renderer');
+  }
 }

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -582,7 +582,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ) {
     throw UnimplementedError();
   }
-  
+
   @override
   ui.BlendEngineLayer pushBlend(int alpha, ui.BlendMode blendMode, {ui.Offset offset = ui.Offset.zero, ui.EngineLayer? oldLayer,}) {
     throw UnimplementedError('Blend is not implemented for the html renderer');


### PR DESCRIPTION
Contains 
* Fix in RenderSurface when resizing website 
* Stubs for web functions in native for analysis
* An initial blend implementation for the canvaskit renderer
* Html image decoder (only works for static images, if we're using / going to use animated images like GIFs or APNG we need to revert this)